### PR TITLE
ISLE-v.1.5.1 Release - Security & software updates. Readme fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN GEN_DEP_PACKS="software-properties-common \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ## S6-Overlay @see: https://github.com/just-containers/s6-overlay
-ENV S6_OVERLAY_VERSION=${S6_OVERLAY_VERSION:-1.22.1.0}
+ENV S6_OVERLAY_VERSION=${S6_OVERLAY_VERSION:-2.0.0.1}
 ADD https://github.com/just-containers/s6-overlay/releases/download/v$S6_OVERLAY_VERSION/s6-overlay-amd64.tar.gz /tmp/
 RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz
@@ -209,7 +209,7 @@ RUN BUILD_DEPS="build-essential \
 
 # Composer & FITS ENV
 # @see: Composer https://github.com/composer/getcomposer.org/commits/master replace hash below with most recent hash & FITS https://projects.iq.harvard.edu/fits/downloads
-ENV COMPOSER_HASH=${COMPOSER_HASH:-4d7f8d40f9788de07c7f7b8946f340bf89535453} \
+ENV COMPOSER_HASH=${COMPOSER_HASH:-ed106feacef086c1fe511f535ad3988d383493d9} \
     FITS_VERSION=${FITS_VERSION:-1.5.0}
 
 ## Let's go!  Finalize all remaining: djatoka, composer, drush, fits.

--- a/README.md
+++ b/README.md
@@ -4,51 +4,49 @@
 Designed as the webserver (httpd) for ISLE. Hosts Drupal and Islandora modules and includes an [install script to provide a quick start!](#loading-the-islelocaldomain-islandora-instance-quickstart)
 
 Based on:  
-  - [Adopt OpenJDK 8 Docker Image](https://hub.docker.com/r/adoptopenjdk/openjdk8)
-  - [Apache HTTPD 2.4](https://httpd.apache.org/)
-  - [PHP 7.1](https://www.php.net/)
+* [Adopt OpenJDK 8 Docker Image](https://hub.docker.com/r/adoptopenjdk/openjdk8)
+* [Apache HTTPD 2.4](https://httpd.apache.org/)
+* [PHP 7.1](https://www.php.net/)
 
 Contains and Includes:
-  - [Composer](https://getcomposer.org)
-  - [Drush 8.x](https://www.drush.org/)
-  - [Tesseract OCR](https://github.com/tesseract-ocr) w/ Language Packs:
-    - DEU (GER)
-    - ENG
-    - FRA
-    - HIN
-    - ITA
-    - JPN
-    - POR
-    - RUS
-    - SPA
-  - Demo Kakadu JP2 library and binaries as made available by the AdoreDjatoka project.
-    - *NOTE*: you will need to purchase a Kakadu license if you intend to use these binaries in production.  
-  - [ImageMagick 7](https://www.imagemagick.org/)
-    - Features: Cipher DPC HDRI OpenMP
-    - Delegates (built-in): bzlib djvu mpeg fontconfig freetype jbig jng jpeg lcms lqr lzma openexr openjp2 png ps raw rsvg tiff webp wmf x zlib
-  - [File Information Tool Set (FITS)](https://projects.iq.harvard.edu/fits/home)
-  - [S6 Overlay](https://github.com/just-containers/s6-overlay) to manage services  
-  - `cron` and `tmpreaper` to clean /tmp
+* [Composer](https://getcomposer.org)
+* [Drush 8.x](https://www.drush.org/)
+* [Tesseract OCR](https://github.com/tesseract-ocr) w/ Language Packs:
+  - DEU (GER)
+  - ENG
+  - FRA
+  - HIN
+  - ITA
+  - JPN
+  - POR
+  - RUS
+  - SPA 
+* [ImageMagick 7](https://www.imagemagick.org/)
+  - Features: Cipher DPC HDRI OpenMP
+  - Delegates (built-in): bzlib djvu mpeg fontconfig freetype jbig jng jpeg lcms lqr lzma openexr openjp2 png ps raw rsvg tiff webp wmf x zlib
+* [File Information Tool Set (FITS)](https://projects.iq.harvard.edu/fits/home)
+* [S6 Overlay](https://github.com/just-containers/s6-overlay) to manage services  
+* `cron` and `tmpreaper` to clean /tmp
+* (_optional_) Demo Kakadu JP2 library and binaries as made available by the AdoreDjatoka project. **NOTE**: you will need to purchase a Kakadu license if you intend to use these binaries in production.
 
 ## Loading the ISLE.localdomain Islandora instance ('quickstart')
 
-* To install the current version of Islandora along with a local Drupal website...  
-`docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh`
+* To install the current version of Islandora along with a local Drupal website...
+  * `docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh`
 
-## Environmental Variables Available:
+## Environmental Variables Available
 
-  - ISLANDORA_UID = 1000 (default)  
-Match the Islandora UID to the user id of the user on the host system responsible for Islandora's webroot.  
-Most distros use UID 1000 for the primary user, so it is the default.  
-**If you are experiencing permission issues on the host when editing your webroot `id -u` to get the appropriate UID to set.**
+* `ISLANDORA_UID = 1000` (default)
+  * Match the Islandora UID to the user id of the user on the host system responsible for Islandora's webroot.
+  * Most distros use UID 1000 for the primary user, so it is the default.
+  * **If you are experiencing permission issues on the host when editing your webroot `id -u` to get the appropriate UID to set.**
 
-  - ENABLE_XDEBUG = false (default) | true  
-Enables the XDEBUG Apache mod for remote debugging.
+* `ENABLE_XDEBUG = false` (default) | true
+  * Enables the XDEBUG Apache mod for remote debugging.
 
-  - PULL_ISLE_BUILD_TOOLS = true (default) | false  
-Fetches the latest ISLE build tools from the (Islandora Collaboration Group)[https://github.com/Islandora-Collaboration-Group/isle_drupal_build_tools]
+* `PULL_ISLE_BUILD_TOOLS = true` (default) | false
+  * Fetches the latest ISLE build tools from the [Islandora Collaboration Group](https://github.com/Islandora-Collaboration-Group/isle_drupal_build_tools)
 
 ## Usage
 
 * For general usage of this image and [ISLE](https://github.com/Islandora-Collaboration-Group/ISLE), please refer to [ISLE documentation](https://islandora-collaboration-group.github.io/ISLE/)
-


### PR DESCRIPTION
* `adoptopenjdk/openjdk8` base image (sec updates)
* `apt-get` dist-upgrades for dependencies (sec updates)
* `S6 overlay` upgraded to [2.0.0.1](https://github.com/just-containers/s6-overlay/releases/tag/v2.0.0.1)
* `ImageMagick` upgraded to version `7.0.10-24`
* `Composer` upgraded to [commit / hash](https://github.com/composer/composer/commit/ed106feacef086c1fe511f535ad3988d383493d9) July 18th, 2020 (v 1.10.9)
* `OpenJpeg` upgraded to [commit / hash](https://github.com/uclouvain/openjpeg/commit/cbee7891a0ee664dd83ca09553d2e30da716a883) June 30th, 2020 (v. 2.3.1)